### PR TITLE
Add PPO contact algorithm with attention-based contact estimator

### DIFF
--- a/engineai_rl/engineai_rl/algos/ppo/__init__.py
+++ b/engineai_rl/engineai_rl/algos/ppo/__init__.py
@@ -1,2 +1,3 @@
 from .ppo import Ppo
 from .ppo_amp.ppo_amp import PpoAmp
+from .ppo_contact.ppo_contact import PpoContact

--- a/engineai_rl/engineai_rl/algos/ppo/ppo_contact/__init__.py
+++ b/engineai_rl/engineai_rl/algos/ppo/ppo_contact/__init__.py
@@ -1,0 +1,1 @@
+from .ppo_contact import PpoContact

--- a/engineai_rl/engineai_rl/algos/ppo/ppo_contact/config_ppo_contact.py
+++ b/engineai_rl/engineai_rl/algos/ppo/ppo_contact/config_ppo_contact.py
@@ -1,0 +1,33 @@
+from engineai_rl.algos.ppo.config_ppo import ConfigPpo
+
+
+class ConfigPpoContact(ConfigPpo):
+    class networks(ConfigPpo.networks):
+        # contact network is used during training but not optimized with PPO
+        training = ["actor", "critic"]
+        inference = ["actor"]
+
+        class contact:
+            class_name = "AttentionNetwork"
+            input_infos = {"num_input_dim": "contact"}
+            output_infos = {"num_output_dim": 4}
+            hidden_dim = 128
+            num_heads = 4
+            num_layers = 2
+
+    class input(ConfigPpo.input):
+        training = ["actor", "critic", "contact"]
+        inference = ["actor", "contact"]
+
+        class components(ConfigPpo.input.components):
+            class contact:
+                obs_list = [
+                    "dof_pos",
+                    "dof_vel",
+                    "base_ang_vel",
+                    "base_euler_xyz",
+                ]
+                obs_with_goals = False
+                obs_history_length = 1
+                obs_goals_history = False
+                obs_history_with_goals = False

--- a/engineai_rl/engineai_rl/algos/ppo/ppo_contact/ppo_contact.py
+++ b/engineai_rl/engineai_rl/algos/ppo/ppo_contact/ppo_contact.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import torch
+from engineai_rl.algos.ppo import Ppo
+
+
+class PpoContact(Ppo):
+    def __init__(self, networks, policy_cfg, env, device="cpu", **kwargs):
+        self.contact_net = networks["contact"]
+        super().__init__(networks, policy_cfg, env, device=device, **kwargs)
+
+    def act(self, inputs):
+        contact_feat = self.contact_net(inputs["contact"]).detach()
+        actor_inputs = inputs.copy()
+        actor_inputs["actor"] = torch.cat((inputs["actor"], contact_feat), dim=-1)
+        self.transition.actions = self.actor_critic.act(actor_inputs).detach()
+        self.transition.values = self.actor_critic.evaluate(actor_inputs).detach()
+        self.transition.actions_log_prob = self.actor_critic.get_actions_log_prob(self.transition.actions).detach()
+        self.transition.action_mean = self.actor_critic.action_mean.detach()
+        self.transition.action_sigma = self.actor_critic.action_std.detach()
+        self.transition.inputs = actor_inputs
+        return self.transition.actions
+
+    def compute_returns(self, inputs):
+        contact_feat = self.contact_net(inputs["contact"]).detach()
+        actor_inputs = inputs.copy()
+        actor_inputs["actor"] = torch.cat((inputs["actor"], contact_feat), dim=-1)
+        last_values = self.actor_critic.evaluate(actor_inputs).detach()
+        self.storage.compute_returns(last_values, self.gamma, self.lam)

--- a/engineai_rl/engineai_rl/exps/biped/dora2/config_dora2_ppo_contact.py
+++ b/engineai_rl/engineai_rl/exps/biped/dora2/config_dora2_ppo_contact.py
@@ -1,0 +1,66 @@
+from engineai_rl.algos.ppo.ppo_contact.config_ppo_contact import ConfigPpoContact
+
+
+class ConfigDora2PpoContact(ConfigPpoContact):
+    class params(ConfigPpoContact.params):
+        entropy_coef = 0.001
+        learning_rate = 1e-5
+        num_learning_epochs = 2
+        gamma = 0.994
+        lam = 0.9
+
+    class runner(ConfigPpoContact.runner):
+        seed = 5
+        num_steps_per_env = 60
+        max_iterations = 30000
+
+    class networks(ConfigPpoContact.networks):
+        class critic(ConfigPpoContact.networks.critic):
+            hidden_dims = [768, 256, 128]
+
+    class input(ConfigPpoContact.input):
+        class components(ConfigPpoContact.input.components):
+            goal_list = ["gait_phase", "commands"]
+
+            class actor(ConfigPpoContact.input.components.actor):
+                obs_history_length = 15
+                obs_list = [
+                    "dof_pos",
+                    "dof_vel",
+                    "actions",
+                    "base_ang_vel",
+                    "base_euler_xyz",
+                ]
+
+            class critic(ConfigPpoContact.input.components.critic):
+                obs_history_length = 3
+                obs_list = [
+                    "base_lin_vel",
+                    "dof_pos",
+                    "dof_vel",
+                    "actions",
+                    "dof_pos_ref_diff",
+                    "base_ang_vel",
+                    "base_euler_xyz",
+                    "rand_push_force",
+                    "rand_push_torque",
+                    "terrain_frictions",
+                    "body_mass",
+                    "stance_curve",
+                    "swing_curve",
+                    "contact_mask",
+                    "height_measurements",
+                ]
+
+        class obs_noise(ConfigPpoContact.input.obs_noise):
+            noise_level = 1.5
+
+            class scales(ConfigPpoContact.input.obs_noise.scales):
+                actor = {
+                    "base_ang_vel": 0.2,
+                    "projected_gravity": 0.05,
+                    "dof_pos": 0.02,
+                    "dof_vel": 2.5,
+                    "base_euler_xyz": 0.1,
+                }
+

--- a/engineai_rl/engineai_rl/modules/networks/__init__.py
+++ b/engineai_rl/engineai_rl/modules/networks/__init__.py
@@ -1,1 +1,2 @@
 from .mlp import Mlp
+from .attention import AttentionNetwork

--- a/engineai_rl/engineai_rl/modules/networks/attention.py
+++ b/engineai_rl/engineai_rl/modules/networks/attention.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from .network_base import NetworkBase
+
+
+class AttentionNetwork(NetworkBase):
+    def __init__(
+        self,
+        num_input_dim,
+        num_output_dim,
+        hidden_dim=128,
+        num_heads=4,
+        num_layers=2,
+        orthogonal_init=False,
+        normalizer=None,
+    ):
+        super().__init__(num_input_dim, num_output_dim, orthogonal_init, normalizer)
+        self.embed = nn.Linear(num_input_dim, hidden_dim)
+        self.attn_layers = nn.ModuleList(
+            [nn.MultiheadAttention(hidden_dim, num_heads) for _ in range(num_layers)]
+        )
+        self.head = nn.Linear(hidden_dim, num_output_dim)
+        self.activation = nn.ReLU()
+
+    def pure_forward(self, x):
+        # x expected shape: (batch, seq_len, dim)
+        x = self.embed(x)
+        x = x.transpose(0, 1)  # seq_len, batch, hidden
+        for attn in self.attn_layers:
+            x, _ = attn(x, x, x)
+        x = x.mean(dim=0)
+        x = self.activation(x)
+        return self.head(x)

--- a/engineai_rl_workspace/exps/biped/dora2.py
+++ b/engineai_rl_workspace/exps/biped/dora2.py
@@ -1,8 +1,9 @@
 from engineai_rl_workspace.utils.exp_registry import exp_registry
 
 from engineai_gym.envs.robots.biped.dora2.config_dora2_rough import ConfigDora2Rough
-from engineai_rl.algos.ppo import Ppo
+from engineai_rl.algos.ppo import Ppo, PpoContact
 from engineai_rl.exps.biped.dora2.config_dora2_ppo import ConfigDora2Ppo
+from engineai_rl.exps.biped.dora2.config_dora2_ppo_contact import ConfigDora2PpoContact
 from engineai_gym.envs.robots.biped.dora2.dora2 import Dora2
 from engineai_gym.envs.robots.biped.rewards_biped import RewardsBiped
 from engineai_gym.envs.robots.biped.goals_biped import GoalsBiped
@@ -15,4 +16,14 @@ exp_registry.register(
     env_cfg=ConfigDora2Rough(),
     algo_class=Ppo,
     algo_cfg=ConfigDora2Ppo(),
+)
+
+exp_registry.register(
+    name="dora2_rough_ppo_contact",
+    task_class=Dora2,
+    goal_class=GoalsBiped,
+    reward_class=RewardsBiped,
+    env_cfg=ConfigDora2Rough(),
+    algo_class=PpoContact,
+    algo_cfg=ConfigDora2PpoContact(),
 )


### PR DESCRIPTION
## Summary
- add `AttentionNetwork` module
- add `PpoContact` algorithm that prepends a contact estimator before the actor
- expose `PpoContact` via package init
- add Dora2 experiment configuration for PPO contact
- register new `dora2_rough_ppo_contact` experiment

## Testing
- `python -m py_compile engineai_rl/engineai_rl/modules/networks/attention.py engineai_rl/engineai_rl/algos/ppo/ppo_contact/ppo_contact.py engineai_rl/engineai_rl/algos/ppo/ppo_contact/config_ppo_contact.py engineai_rl/engineai_rl/algos/ppo/__init__.py engineai_rl_workspace/exps/biped/dora2.py engineai_rl/engineai_rl/exps/biped/dora2/config_dora2_ppo_contact.py`

------
https://chatgpt.com/codex/tasks/task_e_687869bb1b508320a75d7e39ad593097